### PR TITLE
repositioning the player number for small banner

### DIFF
--- a/modules/dsi/image.php
+++ b/modules/dsi/image.php
@@ -194,7 +194,7 @@ if($do_new){
 			pretty_text_ttf($im,$size2,0,18,10,$text_color0,$text_font0,substr($name,0,45), $txt_outline); // Servername
 			pretty_text_ttf($im,$size3,0,2,24,$text_color0,$text_font1,$ip.":".$port, $txt_outline); // IP:Port
 			pretty_text_ttf($im,$size3,0,135,24,$text_color0,$text_font1,$map, $txt_outline); // Map
-			pretty_text_ttf($im,$size3,0,240,24,$text_color0,$text_font1,$players."/".$playersmax, $txt_outline); // Players
+			pretty_text_ttf($im,$size3,0,295,10,$text_color0,$text_font1,$players."/".$playersmax, $txt_outline); // Players
 			pretty_text_ttf($im,$size3,0,295,24,$text_color0,$text_font1,$status, $txt_outline); // Status
 		break;
 		


### PR DESCRIPTION
Before modification the player number is most of the time mixed with the map name (unless the map name are not long ones), repositioning the player number in the top right corner may be better to avoid that problem. 

See the image example here: http://img11.hostingpics.net/pics/402492gitdsdi.png


//EDIT: closed the request as this place belong to the flag position when you enable it in the module files.